### PR TITLE
Improvements regarding records creation limitations.

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/DepthLimitationObjectFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/DepthLimitationObjectFactory.java
@@ -1,0 +1,20 @@
+package org.jeasy.random;
+
+import org.jeasy.random.util.ReflectionUtils;
+
+import java.lang.reflect.Array;
+
+class DepthLimitationObjectFactory {
+    static Object produceEmptyValueForField(Class<?> fieldType) {
+        if (ReflectionUtils.isArrayType(fieldType)) {
+            return Array.newInstance(fieldType.getComponentType(), 0);
+        }
+        if (ReflectionUtils.isCollectionType(fieldType)) {
+            return ReflectionUtils.getEmptyImplementationForCollectionInterface(fieldType);
+        }
+        if (ReflectionUtils.isMapType(fieldType)) {
+            return ReflectionUtils.getEmptyImplementationForMapInterface(fieldType);
+        }
+        return null;
+    }
+}

--- a/easy-random-core/src/main/java/org/jeasy/random/DepthLimitationObjectFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/DepthLimitationObjectFactory.java
@@ -1,10 +1,10 @@
 package org.jeasy.random;
 
+import java.lang.reflect.Array;
 import org.jeasy.random.util.ReflectionUtils;
 
-import java.lang.reflect.Array;
-
 class DepthLimitationObjectFactory {
+
     static Object produceEmptyValueForField(Class<?> fieldType) {
         if (ReflectionUtils.isArrayType(fieldType)) {
             return Array.newInstance(fieldType.getComponentType(), 0);

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
@@ -143,7 +143,7 @@ public class EasyRandom extends Random {
             }
 
             if (isRecord(type)) {
-                return new RecordFactory().createInstance(type, context);
+                return new RecordFactory(context).createInstance(type, context);
             }
 
             // Collection types are randomized without introspection for internal fields

--- a/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
@@ -91,7 +91,8 @@ class RandomizationContext implements RandomizerContext {
         return String.join(".", toLowerCase(pathToField));
     }
 
-    boolean hasExceededRandomizationDepth() {
+    @Override
+    public boolean hasExceededRandomizationDepth() {
         int currentRandomizationDepth = stack.size();
         return currentRandomizationDepth > parameters.getRandomizationDepth();
     }

--- a/easy-random-core/src/main/java/org/jeasy/random/RecordFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RecordFactory.java
@@ -31,7 +31,6 @@ import static org.jeasy.random.util.ReflectionUtils.isOptionalType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
-
 import org.jeasy.random.api.RandomizerContext;
 
 /**
@@ -77,15 +76,13 @@ public class RecordFactory extends ObjenesisObjectFactory {
                     randomValues[i] = new ArrayPopulator(easyRandom).getRandomArray(type, context);
                 } else if (isMapType(type)) {
                     randomValues[i] =
-                            new MapPopulator(easyRandom, context.getParameters().getObjectFactory())
-                                    .getRandomMap(genericType, type, context);
+                        new MapPopulator(easyRandom, context.getParameters().getObjectFactory())
+                            .getRandomMap(genericType, type, context);
                 } else if (isOptionalType(type)) {
-                    randomValues[i] =
-                            new OptionalPopulator(easyRandom).getRandomOptional(genericType, context);
+                    randomValues[i] = new OptionalPopulator(easyRandom).getRandomOptional(genericType, context);
                 } else if (isCollectionType(type)) {
                     randomValues[i] =
-                            new CollectionPopulator(easyRandom)
-                                    .getRandomCollection(genericType, type, context);
+                        new CollectionPopulator(easyRandom).getRandomCollection(genericType, type, context);
                 } else {
                     randomValues[i] = easyRandom.doPopulateBean(type, context);
                 }

--- a/easy-random-core/src/main/java/org/jeasy/random/RecordFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RecordFactory.java
@@ -31,48 +31,73 @@ import static org.jeasy.random.util.ReflectionUtils.isOptionalType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
+
 import org.jeasy.random.api.RandomizerContext;
 
+/**
+ * What is the justification for extending ObjenesisObjectFactory?
+ * RecordFactory, to support nesting depth, needs access to context implementation which renders the interface (RandomizerContext)
+ * introduced by ObjenesisObjectFactory method signature redundant. Abandoning the inheritance will hence simplify the
+ * implementation by reducing the number of parameters, and by additionally storing the instance of RecordFactory as a field in
+ * the EasyRandom class.
+ */
 public class RecordFactory extends ObjenesisObjectFactory {
 
     private EasyRandom easyRandom;
+    private final RandomizationContext contextImpl;
+
+    public RecordFactory(RandomizationContext contextImpl) {
+        this.contextImpl = contextImpl;
+    }
 
     @Override
     public <T> T createInstance(Class<T> type, RandomizerContext context) {
         if (easyRandom == null) {
-            easyRandom = new EasyRandom(context.getParameters());
+            easyRandom = new EasyRandom(contextImpl.getParameters());
         }
-        return createRandomRecord(type, context);
+        return createRandomRecord(type, contextImpl);
     }
 
-    private <T> T createRandomRecord(Class<T> recordType, RandomizerContext context) {
+    private <T> T createRandomRecord(Class<T> recordType, RandomizationContext context) {
         // generate random values for record components
         RecordComponent[] recordComponents = recordType.getRecordComponents();
         Object[] randomValues = new Object[recordComponents.length];
 
-        for (int i = 0; i < recordComponents.length; i++) {
-            Class<?> type = recordComponents[i].getType();
-            Type genericType = recordComponents[i].getGenericType();
-            if (isArrayType(type)) {
-                randomValues[i] = new ArrayPopulator(easyRandom).getRandomArray(type, (RandomizationContext) context);
-            } else if (isMapType(type)) {
-                randomValues[i] =
-                    new MapPopulator(easyRandom, context.getParameters().getObjectFactory())
-                        .getRandomMap(genericType, type, (RandomizationContext) context);
-            } else if (isOptionalType(type)) {
-                randomValues[i] =
-                    new OptionalPopulator(easyRandom).getRandomOptional(genericType, (RandomizationContext) context);
-            } else if (isCollectionType(type)) {
-                randomValues[i] =
-                    new CollectionPopulator(easyRandom)
-                        .getRandomCollection(genericType, type, (RandomizationContext) context);
-            } else {
-                randomValues[i] = easyRandom.nextObject(type);
+        if (context.hasExceededRandomizationDepth()) {
+            for (int i = 0; i < recordComponents.length; i++) {
+                Class<?> type = recordComponents[i].getType();
+                randomValues[i] = DepthLimitationObjectFactory.produceEmptyValueForField(type);
+            }
+        } else {
+            for (int i = 0; i < recordComponents.length; i++) {
+                context.pushStackItem(new RandomizationContextStackItem(recordType, null));
+                Class<?> type = recordComponents[i].getType();
+                Type genericType = recordComponents[i].getGenericType();
+                if (isArrayType(type)) {
+                    randomValues[i] = new ArrayPopulator(easyRandom).getRandomArray(type, context);
+                } else if (isMapType(type)) {
+                    randomValues[i] =
+                            new MapPopulator(easyRandom, context.getParameters().getObjectFactory())
+                                    .getRandomMap(genericType, type, context);
+                } else if (isOptionalType(type)) {
+                    randomValues[i] =
+                            new OptionalPopulator(easyRandom).getRandomOptional(genericType, context);
+                } else if (isCollectionType(type)) {
+                    randomValues[i] =
+                            new CollectionPopulator(easyRandom)
+                                    .getRandomCollection(genericType, type, context);
+                } else {
+                    randomValues[i] = easyRandom.doPopulateBean(type, context);
+                }
+                context.popStackItem();
             }
         }
+
         // create a random instance with random values
         try {
-            return getCanonicalConstructor(recordType).newInstance(randomValues);
+            Constructor<T> canonicalConstructor = getCanonicalConstructor(recordType);
+            canonicalConstructor.setAccessible(true);
+            return canonicalConstructor.newInstance(randomValues);
         } catch (Exception e) {
             throw new ObjectCreationException("Unable to create a random instance of recordType " + recordType, e);
         }

--- a/easy-random-core/src/main/java/org/jeasy/random/api/RandomizerContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/api/RandomizerContext.java
@@ -68,4 +68,10 @@ public interface RandomizerContext {
      * @return currently used parameters
      */
     EasyRandomParameters getParameters();
+
+    /**
+     * Checks if the current randomization depth reached the configured maximum
+     * @return true when on the deepest level
+     */
+    boolean hasExceededRandomizationDepth();
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/DirectlyNested.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/DirectlyNested.java
@@ -1,4 +1,3 @@
 package org.jeasy.random.beans;
 
-public record DirectlyNested(DirectlyNested child, Integer value) {
-}
+public record DirectlyNested(DirectlyNested child, Integer value) {}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/DirectlyNested.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/DirectlyNested.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans;
+
+public record DirectlyNested(DirectlyNested child, Integer value) {
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/NestedRecordThroughCollection.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/NestedRecordThroughCollection.java
@@ -2,5 +2,4 @@ package org.jeasy.random.beans;
 
 import java.util.List;
 
-public record NestedRecordThroughCollection(List<NestedRecordThroughCollection> children) {
-}
+public record NestedRecordThroughCollection(List<NestedRecordThroughCollection> children) {}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/NestedRecordThroughCollection.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/NestedRecordThroughCollection.java
@@ -1,0 +1,6 @@
+package org.jeasy.random.beans;
+
+import java.util.List;
+
+public record NestedRecordThroughCollection(List<NestedRecordThroughCollection> children) {
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/RecordLimitationsTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/RecordLimitationsTest.java
@@ -1,0 +1,78 @@
+package org.jeasy.random.beans;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordLimitationsTest {
+
+    @Test
+    void shouldGenerateNonPublicClasses() {
+        //given
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        EasyRandom easyRandom = new EasyRandom(parameters);
+
+        //when
+        WrapperOfNonPublic.NonPublicClass ordinaryClass = easyRandom.nextObject(WrapperOfNonPublic.NonPublicClass.class);
+
+        //then
+        assertThat(ordinaryClass.name).isNotEmpty();
+    }
+
+    //This tst fail despite its counterpart regarding classes passes.
+    @Test
+    void shouldGenerateNonPublicRecords() {
+        //given
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        EasyRandom easyRandom = new EasyRandom(parameters);
+
+        //when
+        WrapperOfNonPublic.NonPublicRecord record = easyRandom.nextObject(WrapperOfNonPublic.NonPublicRecord.class);
+
+        //then
+        assertThat(record.name()).isNotEmpty();
+    }
+
+    @Test
+    @Timeout(3)
+    void shouldLimitTheNestingLevel_whenInDirectlyRecursiveStructures() {
+        //given
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.randomizationDepth(2);
+        EasyRandom easyRandom = new EasyRandom(parameters);
+
+        //when
+        DirectlyNested actual = easyRandom.nextObject(DirectlyNested.class);
+
+        //then
+        assertThat(actual.value()).isNotNull();
+        assertThat(actual.child().child().child())
+                .as("On the 3rd level, the field values should equal null, i.e. end of nesting.")
+                .isEqualTo(new DirectlyNested(null,null));
+        assertThat(actual.child().child().value()).isNotNull();
+    }
+
+    @Test
+    @Timeout(3)
+    void shouldLimitTheNestingLevel_whenInRecursiveStructures() {
+        //given
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.randomizationDepth(1);
+        parameters.setCollectionSizeRange(new EasyRandomParameters.Range<>(1,2));
+        EasyRandom easyRandom = new EasyRandom(parameters);
+
+        //when
+        NestedRecordThroughCollection actual = easyRandom.nextObject(NestedRecordThroughCollection.class);
+
+        //then
+        assertThat(actual.children()).isNotEmpty();
+        assertThat(actual.children().get(0).children().get(0))
+                .as("On the 2nd level, the field should be initialized with empty list, i.e. end of nesting.")
+                .isEqualTo(new NestedRecordThroughCollection(List.of()));
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/RecordLimitationsTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/RecordLimitationsTest.java
@@ -1,13 +1,12 @@
 package org.jeasy.random.beans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class RecordLimitationsTest {
 
@@ -18,7 +17,9 @@ public class RecordLimitationsTest {
         EasyRandom easyRandom = new EasyRandom(parameters);
 
         //when
-        WrapperOfNonPublic.NonPublicClass ordinaryClass = easyRandom.nextObject(WrapperOfNonPublic.NonPublicClass.class);
+        WrapperOfNonPublic.NonPublicClass ordinaryClass = easyRandom.nextObject(
+            WrapperOfNonPublic.NonPublicClass.class
+        );
 
         //then
         assertThat(ordinaryClass.name).isNotEmpty();
@@ -52,8 +53,8 @@ public class RecordLimitationsTest {
         //then
         assertThat(actual.value()).isNotNull();
         assertThat(actual.child().child().child())
-                .as("On the 3rd level, the field values should equal null, i.e. end of nesting.")
-                .isEqualTo(new DirectlyNested(null,null));
+            .as("On the 3rd level, the field values should equal null, i.e. end of nesting.")
+            .isEqualTo(new DirectlyNested(null, null));
         assertThat(actual.child().child().value()).isNotNull();
     }
 
@@ -63,7 +64,7 @@ public class RecordLimitationsTest {
         //given
         EasyRandomParameters parameters = new EasyRandomParameters();
         parameters.randomizationDepth(1);
-        parameters.setCollectionSizeRange(new EasyRandomParameters.Range<>(1,2));
+        parameters.setCollectionSizeRange(new EasyRandomParameters.Range<>(1, 2));
         EasyRandom easyRandom = new EasyRandom(parameters);
 
         //when
@@ -72,7 +73,7 @@ public class RecordLimitationsTest {
         //then
         assertThat(actual.children()).isNotEmpty();
         assertThat(actual.children().get(0).children().get(0))
-                .as("On the 2nd level, the field should be initialized with empty list, i.e. end of nesting.")
-                .isEqualTo(new NestedRecordThroughCollection(List.of()));
+            .as("On the 2nd level, the field should be initialized with empty list, i.e. end of nesting.")
+            .isEqualTo(new NestedRecordThroughCollection(List.of()));
     }
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/WrapperOfNonPublic.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/WrapperOfNonPublic.java
@@ -1,0 +1,10 @@
+package org.jeasy.random.beans;
+
+public class WrapperOfNonPublic {
+    record NonPublicRecord(String name) {
+    }
+
+    class NonPublicClass {
+        String name;
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/WrapperOfNonPublic.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/WrapperOfNonPublic.java
@@ -1,10 +1,11 @@
 package org.jeasy.random.beans;
 
 public class WrapperOfNonPublic {
-    record NonPublicRecord(String name) {
-    }
+
+    record NonPublicRecord(String name) {}
 
     class NonPublicClass {
+
         String name;
     }
 }


### PR DESCRIPTION
Current records creation solution:
- does not support creating non-public records (when using easy-random for test data it is inconvenient as it is not unusual to have some package-level data structure and a unit test located in the same package)
- does not respect easy-random `randomizationDepth` parameter

This PR delivers unit tests that detect the lack of the aforementioned features and an implementation that passes those tests.
