### PR TITLE
Ensure compatibility with Android's limited Java SE subset

### DIFF
--- a/easy-random-bean-validation/pom.xml
+++ b/easy-random-bean-validation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.dvgaba</groupId>
     <artifactId>easy-random</artifactId>
-    <version>7.1.0</version>
+    <version>7.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>easy-random-bean-validation</artifactId>

--- a/easy-random-core/pom.xml
+++ b/easy-random-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.dvgaba</groupId>
     <artifactId>easy-random</artifactId>
-    <version>7.1.0</version>
+    <version>7.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>easy-random-core</artifactId>

--- a/easy-random-core/src/main/java/org/jeasy/random/ObjenesisObjectFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/ObjenesisObjectFactory.java
@@ -75,7 +75,11 @@ public class ObjenesisObjectFactory implements ObjectFactory {
     private <T> T createNewInstance(final Class<T> type) {
         try {
             Constructor<T> noArgConstructor = type.getDeclaredConstructor();
-            noArgConstructor.trySetAccessible();
+            try {
+                noArgConstructor.trySetAccessible();
+            } catch(NoSuchMethodError e) {
+                noArgConstructor.setAccessible(true);
+            }
             return noArgConstructor.newInstance();
         } catch (Exception exception) {
             return objenesis.newInstance(type);

--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/registry/InternalRandomizerRegistry.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/registry/InternalRandomizerRegistry.java
@@ -23,14 +23,13 @@
  */
 package org.jeasy.random.randomizers.registry;
 
-import static java.sql.Date.valueOf;
-
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -131,5 +130,9 @@ public class InternalRandomizerRegistry implements RandomizerRegistry {
     @Override
     public Randomizer<?> getRandomizer(Class<?> type) {
         return randomizers.get(type);
+    }
+
+    private static Date valueOf(LocalDate date) {
+        return new Date(date.getYear() - 1900, date.getMonthValue() -1, date.getDayOfMonth());
     }
 }

--- a/easy-random-core/src/main/java/org/jeasy/random/util/ReflectionUtils.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/util/ReflectionUtils.java
@@ -151,9 +151,14 @@ public final class ReflectionUtils {
      */
     public static void setFieldValue(final Object object, final Field field, final Object value)
             throws IllegalAccessException {
-        boolean access = field.trySetAccessible();
-        field.set(object, value);
-        field.setAccessible(access);
+        try {
+            boolean access = field.trySetAccessible();
+            field.set(object, value);
+            field.setAccessible(access);
+        } catch (NoSuchMethodError e) {
+            field.setAccessible(true);
+            field.set(object, value);
+        }
     }
 
     /**

--- a/easy-random-protobuf/pom.xml
+++ b/easy-random-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.dvgaba</groupId>
     <artifactId>easy-random</artifactId>
-    <version>7.1.0</version>
+    <version>7.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>easy-random-protobuf</artifactId>

--- a/easy-random-randomizers/pom.xml
+++ b/easy-random-randomizers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.dvgaba</groupId>
     <artifactId>easy-random</artifactId>
-    <version>7.1.0</version>
+    <version>7.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>easy-random-randomizers</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.dvgaba</groupId>
   <artifactId>easy-random</artifactId>
-  <version>7.1.0</version>
+  <version>7.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>


### PR DESCRIPTION
Ensure compatibility with Android's limited Java SE subset.

Android utilizes a subset of the Java SE library, which excludes several packages and classes. This commit removes calls to methods unavailable on Android or wraps them in `try-catch` blocks with appropriate fallbacks. These changes ensure the Easy Random library functions correctly on Android platforms.

